### PR TITLE
Fixed PyPy compatibility.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.10 (unreleased)
 =================
 
-- Nothing changed yet.
+- Fixed PyPy compatibility. [hathawsh]
 
 
 0.9 (2014-10-04)

--- a/collective/recipe/cmd/__init__.py
+++ b/collective/recipe/cmd/__init__.py
@@ -30,7 +30,9 @@ def run_commands(cmds, shell):
             lines.insert(0, '@echo off')
         else:
             tmpfile = os.path.join(dirname, 'run')
-        open(tmpfile, 'w').write('\n'.join(lines))
+        f = open(tmpfile, 'w')
+        f.write('\n'.join(lines))
+        f.close()
         if sys.platform == 'win32':
             check_call(tmpfile, shell=True)
         else:
@@ -94,6 +96,8 @@ class Python(Cmd):
                     doctest.Example)]
             dirname = tempfile.mkdtemp()
             tmpfile = os.path.join(dirname, 'run.py')
-            open(tmpfile, 'w').writelines(lines)
+            f = open(tmpfile, 'w')
+            f.writelines(lines)
+            f.close()
             execfile(tmpfile)
             shutil.rmtree(dirname)


### PR DESCRIPTION
Due to garbage collection behavior differences, when running in PyPy, collective.recipe.cmd would create an empty script file and tried to execute it. This patch explicitly closes the script file, forcing the script to be written before execution.