### PR TITLE
Add support for Python 3.2 and PyPy3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 develop-eggs
 *.pyc
 *.egg-info
+eggs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: python
 python:
   - "2.7"
+  - "3.2"
   - "3.3"
   - "3.4"
-#  - "2.6"
+  - "pypy"
+  - "pypy3"
 install:
   - python bootstrap.py -c buildout.cfg
   - bin/buildout annotate
   - bin/buildout -N -q
-# - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors unittest2; fi
 script: bin/test
 after_failure:
   - bin/buildout annotate

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 0.11 (unreleased)
 =================
 
-- Nothing changed yet.
+- Add support for Python 3.2 and PyPy3.
+- Add support for testing with tox.
+- Fix compatibility with ``zope.testing`` 4.2.0.
+- Add version and implementation trove classifiers.
 
 
 0.10 (2015-02-25)

--- a/collective/recipe/cmd/tests/test_docs.py
+++ b/collective/recipe/cmd/tests/test_docs.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+import doctest
 import os
 import sys
 import unittest
 import zc.buildout.tests
 import zc.buildout.testing
-from zope.testing import doctest, renormalizing
+from zope.testing import renormalizing
 """
 Doctest runner for 'collective.recipe.cmd'.
 """

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,16 @@
 """
 This module contains the tool of collective.recipe.cmd
 """
+import codecs
 from setuptools import find_packages
 from setuptools import setup
 
 version = '0.11.dev0'
 description = 'A Buildout recipe to execute commands in the console user interface'
-long_description = (
-    open('README.rst').read() + '\n' +
-    open('CONTRIBUTORS.rst').read() + '\n' +
-    open('CHANGES.rst').read()
-)
+long_description = ''
+for f in 'README.rst', 'CONTRIBUTORS.rst', 'CHANGES.rst':
+    with codecs.open(f, 'r', encoding='UTF-8') as of:
+        long_description += of.read() + '\n'
 
 entry_point = 'collective.recipe.cmd'
 entry_points = {"zc.buildout": [
@@ -39,6 +39,15 @@ setup(name='collective.recipe.cmd',
           'Topic :: Software Development :: Build Tools',
           'Topic :: Software Development :: Libraries :: Python Modules',
           'License :: OSI Approved :: BSD License',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.2',
+          'Programming Language :: Python :: 3.3',
+          'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: Implementation :: CPython',
+          'Programming Language :: Python :: Implementation :: PyPy',
       ],
       keywords='buildout recipe',
       author='Gael Pasgrimaud',

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,6 @@ deps =
     zope.testing
     zc.buildout
     manuel
-	zope.testrunner
+    zope.testrunner
 commands =
     zope-testrunner --path=. --test-path=. --auto-color --auto-progress

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist =
+    py27,pypy,py32,py33,py34,pypy3
+
+
+[testenv]
+usedevelop = true
+deps =
+    zope.testing
+    zc.buildout
+    manuel
+	zope.testrunner
+commands =
+    zope-testrunner --path=. --test-path=. --auto-color --auto-progress


### PR DESCRIPTION
- Add support for testing with tox.
- Fix compatibility with ``zope.testing`` 4.2.0.
- Add version and implementation trove classifiers.

This is one of the blockers for being able to run zopetoolkit builds under PyPy3/3.2 (zopefoundation/zopetoolkit#3).